### PR TITLE
Murmorhash 2 is not supported on node 4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/optimizely/hyperloglog.git"
   },
   "dependencies": {
-    "murmurhash3": "0.2.x"
+    "murmurhash3": "0.3.x"
   },
   "devDependencies": {
     "vows": "0.7.x"


### PR DESCRIPTION
- [x] Update dependency to make the package work on Node 4+
