### PR TITLE
fix: Update murmurhash3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/optimizely/hyperloglog.git"
   },
   "dependencies": {
-    "murmurhash3": "0.2.x"
+    "murmurhash3": "^0.4.0"
   },
   "devDependencies": {
     "vows": "0.7.x"


### PR DESCRIPTION
The current provided version of murmurhash3 does not work on newver
versions of node.

PS: I see there is already a PR for an update of murmurhash3